### PR TITLE
Make description of defaults correspond with method

### DIFF
--- a/lib/dnsimple/default.rb
+++ b/lib/dnsimple/default.rb
@@ -56,13 +56,13 @@ module Dnsimple
         ENV['DNSIMPLE_API_EXCHANGE_TOKEN']
       end
 
-      # Default DNSimple API Token for Token Auth from ENV
+      # Default DNSimple Domain API Token for Token Auth from ENV
       # @return [String]
       def domain_api_token
         ENV['DNSIMPLE_DOMAIN_API_TOKEN']
       end
 
-      # Default DNSimple Domain API Token for Token Auth from ENV
+      # Default DNSimple API Token for Token Auth from ENV
       # @return [String]
       def api_token
         ENV['DNSIMPLE_API_TOKEN']

--- a/lib/dnsimple/default.rb
+++ b/lib/dnsimple/default.rb
@@ -59,13 +59,13 @@ module Dnsimple
       # Default DNSimple API Token for Token Auth from ENV
       # @return [String]
       def domain_api_token
-        ENV['DNSIMPLE_API_TOKEN']
+        ENV['DNSIMPLE_DOMAIN_API_TOKEN']
       end
 
       # Default DNSimple Domain API Token for Token Auth from ENV
       # @return [String]
       def api_token
-        ENV['DNSIMPLE_API_DOMAIN_TOKEN']
+        ENV['DNSIMPLE_API_TOKEN']
       end
 
       # Default User-Agent header string from ENV or {USER_AGENT}


### PR DESCRIPTION
Currently `Default.domain_api_token` refers `ENV["DNSIMPLE_API_TOKEN"]` and `Default.api_token` refers `ENV["DNSIMPLE_API_DOMAIN_TOKEN"]`.
These are difficult to understand and implement with this library...

In this PR I make these env names correspond with method names refering these envs.