### PR TITLE
Flip the environment variables for api token & domain api token

### DIFF
--- a/lib/dnsimple/default.rb
+++ b/lib/dnsimple/default.rb
@@ -56,16 +56,16 @@ module Dnsimple
         ENV['DNSIMPLE_API_EXCHANGE_TOKEN']
       end
 
-      # Default DNSimple API Token for Token Auth from ENV
-      # @return [String]
-      def domain_api_token
-        ENV['DNSIMPLE_API_TOKEN']
-      end
-
       # Default DNSimple Domain API Token for Token Auth from ENV
       # @return [String]
-      def api_token
+      def domain_api_token
         ENV['DNSIMPLE_API_DOMAIN_TOKEN']
+      end
+
+      # Default DNSimple API Token for Token Auth from ENV
+      # @return [String]
+      def api_token
+        ENV['DNSIMPLE_API_TOKEN']
       end
 
       # Default User-Agent header string from ENV or {USER_AGENT}


### PR DESCRIPTION
It feels like these are currently the wrong way around. Similar to #59 but also flips the method comments

cc/ @parisyee