### PR TITLE
Record type should be :type not :record_type

### DIFF
--- a/lib/dnsimple/client/zones_records.rb
+++ b/lib/dnsimple/client/zones_records.rb
@@ -59,7 +59,7 @@ module Dnsimple
       #
       # @raise  [Dnsimple::RequestError]
       def create_record(account_id, zone_id, attributes = {}, options = {})
-        Extra.validate_mandatory_attributes(attributes, [:record_type, :name, :content])
+        Extra.validate_mandatory_attributes(attributes, [:type, :name, :content])
         options  = options.merge(attributes)
         response = client.post(Client.versioned("/%s/zones/%s/records" % [account_id, zone_id]), options)
 

--- a/spec/dnsimple/client/zones_records_spec.rb
+++ b/spec/dnsimple/client/zones_records_spec.rb
@@ -87,7 +87,7 @@ describe Dnsimple::Client, ".zones" do
           .to_return(read_http_fixture("createZoneRecord/created.http"))
     end
 
-    let(:attributes) { { record_type: "A", name: "www", content: "127.0.0.1" } }
+    let(:attributes) { { type: "A", name: "www", content: "127.0.0.1" } }
 
     it "builds the correct request" do
       subject.create_record(account_id, zone_id, attributes)


### PR DESCRIPTION
We are validating presence of `record_type` when creating a record yet the API expects `type` to be sent.