### PR TITLE
Serialize request body to JSON

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -156,8 +156,12 @@ module Dnsimple
     # @param  [Hash] options The query and header params for the request
     # @return [HTTParty::Response]
     def request(method, path, data = nil, options = {})
-      request_options        = Extra.deep_merge!(base_options, options)
-      request_options[:body] = encoded_data(data, request_options[:headers]) if data
+      request_options = Extra.deep_merge!(base_options, options)
+
+      if data
+        request_options[:headers]["Content-Type"] = content_type(request_options[:headers])
+        request_options[:body] = content_data(request_options[:headers], data)
+      end
 
       HTTParty.send(method, base_url + path, request_options)
     end
@@ -170,7 +174,6 @@ module Dnsimple
           format:   :json,
           headers:  {
             'Accept' => 'application/json',
-            'Content-Type' => 'application/json',
             'User-Agent' => user_agent
           },
       }
@@ -193,7 +196,11 @@ module Dnsimple
       options
     end
 
-    def encoded_data(data, headers)
+    def content_type(headers)
+      headers["Content-Type"] || "application/json"
+    end
+
+    def content_data(headers, data)
       headers["Content-Type"] == "application/json" ? JSON.dump(data) : data
     end
 

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -156,7 +156,7 @@ module Dnsimple
     # @param  [Hash] options The query and header params for the request
     # @return [HTTParty::Response]
     def request(method, path, data = nil, options = {})
-      options[:body] = data if data
+      options[:body] = JSON.dump(data) if data
 
       HTTParty.send(method, base_url + path, Extra.deep_merge!(base_options, options))
     end

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -167,7 +167,11 @@ module Dnsimple
     def base_options
       options = {
           format:   :json,
-          headers:  { 'Accept' => 'application/json', 'User-Agent' => user_agent },
+          headers:  {
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'User-Agent' => user_agent
+          },
       }
 
       if proxy

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -156,9 +156,10 @@ module Dnsimple
     # @param  [Hash] options The query and header params for the request
     # @return [HTTParty::Response]
     def request(method, path, data = nil, options = {})
-      options[:body] = JSON.dump(data) if data
+      request_options        = Extra.deep_merge!(base_options, options)
+      request_options[:body] = encoded_data(data, request_options[:headers]) if data
 
-      HTTParty.send(method, base_url + path, Extra.deep_merge!(base_options, options))
+      HTTParty.send(method, base_url + path, request_options)
     end
 
 
@@ -190,6 +191,10 @@ module Dnsimple
       end
 
       options
+    end
+
+    def encoded_data(data, headers)
+      headers["Content-Type"] == "application/json" ? JSON.dump(data) : data
     end
 
   end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -130,14 +130,14 @@ describe Dnsimple::Client do
                           with("#{subject.base_url}foo",
                                format: :json,
                                basic_auth: { username: "user", password: "pass" },
-                               headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}" }
+                               headers: { 'Accept' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}" }
                           ).
                           and_return(double('response', code: 200))
 
       subject.request(:get, 'foo')
     end
 
-    it "properly extracts options from data" do
+    it "properly extracts processes options and encodes data" do
       expect(HTTParty).to receive(:put).
                           with("#{subject.base_url}foo",
                                format: :json,

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -141,7 +141,7 @@ describe Dnsimple::Client do
       expect(HTTParty).to receive(:put).
                           with("#{subject.base_url}foo",
                                format: :json,
-                               body: { something: "else" },
+                               body: JSON.dump({ something: "else" }),
                                query: { foo: "bar" },
                                basic_auth: { username: "user", password: "pass" },
                                headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}", "Custom" => "Header" }

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -150,6 +150,19 @@ describe Dnsimple::Client do
 
       subject.request(:put, 'foo', { something: "else" }, { query: { foo: "bar" }, headers: { "Custom" => "Header" } })
     end
+
+    it "handles non application/json content types" do
+      expect(HTTParty).to receive(:post).
+                          with("#{subject.base_url}foo",
+                               format: :json,
+                               body: { something: "else" },
+                               basic_auth: { username: "user", password: "pass" },
+                               headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}" }
+                          ).
+                          and_return(double('response', code: 200))
+
+      subject.request(:post, 'foo', { something: "else" }, headers: { "Content-Type" => "application/x-www-form-urlencoded" })
+    end
   end
 
 end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -130,7 +130,7 @@ describe Dnsimple::Client do
                           with("#{subject.base_url}foo",
                                format: :json,
                                basic_auth: { username: "user", password: "pass" },
-                               headers: { 'Accept' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}" }
+                               headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}" }
                           ).
                           and_return(double('response', code: 200))
 
@@ -144,7 +144,7 @@ describe Dnsimple::Client do
                                body: { something: "else" },
                                query: { foo: "bar" },
                                basic_auth: { username: "user", password: "pass" },
-                               headers: { 'Accept' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}", "Custom" => "Header" }
+                               headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}", "Custom" => "Header" }
                           ).
                           and_return(double('response', code: 200))
 


### PR DESCRIPTION
We realized that some attributes weren't arriving correctly to the API. Not serializing the request body appropriately was the reason.

I've used the standard library `JSON` but I'll be happy to use any other library if needed. (I also think this can be kept as is until we introduce Faraday - if we finally do).