### PR TITLE
Implement registrar delegation actions

### DIFF
--- a/lib/dnsimple/client/clients.rb
+++ b/lib/dnsimple/client/clients.rb
@@ -114,11 +114,13 @@ module Dnsimple
     require_relative 'registrar'
     require_relative 'registrar_auto_renewal'
     require_relative 'registrar_whois_privacy'
+    require_relative 'registrar_delegation'
 
     class RegistrarService < ClientService
       include Client::Registrar
       include Client::RegistrarAutoRenewal
       include Client::RegistrarWhoisPrivacy
+      include Client::RegistrarDelegation
     end
 
 

--- a/lib/dnsimple/client/registrar_delegation.rb
+++ b/lib/dnsimple/client/registrar_delegation.rb
@@ -9,6 +9,13 @@ module Dnsimple
         Dnsimple::Response.new(response, response["data"])
       end
 
+      def change_domain_delegation(account_id, domain_name, attributes, options = {})
+        endpoint = Client.versioned("/%s/registrar/domains/%s/delegation" % [account_id, domain_name])
+        response = client.put(endpoint, attributes, options)
+
+        Dnsimple::Response.new(response, response["data"])
+      end
+
     end
   end
 end

--- a/lib/dnsimple/client/registrar_delegation.rb
+++ b/lib/dnsimple/client/registrar_delegation.rb
@@ -2,6 +2,19 @@ module Dnsimple
   class Client
     module RegistrarDelegation
 
+      # Lists name servers the domain is delegating to.
+      #
+      # @see https://developer.dnsimple.com/v2/registrar/delegation/#list
+      #
+      # @example List the name servers example.com is delegating to:
+      #   client.registrar.domain_delegation(1010, "example.com")
+      #
+      # @param  [Fixnum] account_id the account ID
+      # @param  [#to_s] domain_name the domain name to check
+      # @param  [Hash] options
+      # @return [Dnsimple::Response<Array>]
+      #
+      # @raise  [RequestError] When the request fails.
       def domain_delegation(account_id, domain_name, options = {})
         endpoint = Client.versioned("/%s/registrar/domains/%s/delegation" % [account_id, domain_name])
         response = client.get(endpoint, options)
@@ -9,6 +22,21 @@ module Dnsimple
         Dnsimple::Response.new(response, response["data"])
       end
 
+      # Chagne name servers the domain is delegating to.
+      #
+      # @see https://developer.dnsimple.com/v2/registrar/delegation/#update
+      #
+      # @example Change the name servers example.com is delegating to:
+      #   client.registrar.change_domain_delegation(1010, "example.com",
+      #       ["ns1.dnsimple.com", "ns2.dnsimple.com", "ns3.dnsimple.com", "ns4.dnsimple.com"])
+      #
+      # @param  [Fixnum] account_id the account ID
+      # @param  [#to_s] domain_name the domain name to check
+      # @param  [Array] attributes
+      # @param  [Hash] options
+      # @return [Dnsimple::Response<Array>]
+      #
+      # @raise  [RequestError] When the request fails.
       def change_domain_delegation(account_id, domain_name, attributes, options = {})
         endpoint = Client.versioned("/%s/registrar/domains/%s/delegation" % [account_id, domain_name])
         response = client.put(endpoint, attributes, options)

--- a/lib/dnsimple/client/registrar_delegation.rb
+++ b/lib/dnsimple/client/registrar_delegation.rb
@@ -1,0 +1,14 @@
+module Dnsimple
+  class Client
+    module RegistrarDelegation
+
+      def domain_delegation(account_id, domain_name, options = {})
+        endpoint = Client.versioned("/%s/registrar/domains/%s/delegation" % [account_id, domain_name])
+        response = client.get(endpoint, options)
+
+        Dnsimple::Response.new(response, response["data"])
+      end
+
+    end
+  end
+end

--- a/spec/dnsimple/client/registrar_delegation_spec.rb
+++ b/spec/dnsimple/client/registrar_delegation_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Dnsimple::Client, ".registrar" do
+
+  subject { described_class.new(base_url: "https://api.dnsimple.test", access_token: "a1b2c3").registrar }
+
+  describe "#domain_delegation" do
+    let(:account_id) { 1010 }
+
+    before do
+      stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/delegation$}).
+          to_return(read_http_fixture("getDomainDelegation/success.http"))
+    end
+
+    it "builds the correct request" do
+      subject.domain_delegation(account_id, domain_name = "example.com")
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/delegation").
+          with(headers: { "Accept" => "application/json" })
+    end
+
+    it "returns the name servers of the domain" do
+      response = subject.domain_delegation(account_id, "example.com")
+      expect(response).to be_a(Dnsimple::Response)
+
+      expect(response.data).to match_array(%w{ns1.dnsimple.com ns2.dnsimple.com ns3.dnsimple.com ns4.dnsimple.com})
+    end
+  end
+
+end

--- a/spec/dnsimple/client/registrar_delegation_spec.rb
+++ b/spec/dnsimple/client/registrar_delegation_spec.rb
@@ -23,7 +23,7 @@ describe Dnsimple::Client, ".registrar" do
       response = subject.domain_delegation(account_id, "example.com")
       expect(response).to be_a(Dnsimple::Response)
 
-      expect(response.data).to match_array(%w{ns1.dnsimple.com ns2.dnsimple.com ns3.dnsimple.com ns4.dnsimple.com})
+      expect(response.data).to match_array(%w(ns1.dnsimple.com ns2.dnsimple.com ns3.dnsimple.com ns4.dnsimple.com))
     end
   end
 

--- a/spec/dnsimple/client/registrar_delegation_spec.rb
+++ b/spec/dnsimple/client/registrar_delegation_spec.rb
@@ -27,4 +27,29 @@ describe Dnsimple::Client, ".registrar" do
     end
   end
 
+  describe "#change_domain_delegation" do
+    let(:account_id) { 1010 }
+
+    before do
+      stub_request(:put, %r{/v2/#{account_id}/registrar/domains/.+/delegation$}).
+          to_return(read_http_fixture("changeDomainDelegation/success.http"))
+    end
+
+    let(:attributes) { %w(ns1.dnsimple.com ns2.dnsimple.com ns3.dnsimple.com ns4.dnsimple.com) }
+
+    it "builds the correct request" do
+      subject.change_domain_delegation(account_id, domain_name = "example.com", attributes)
+
+      expect(WebMock).to have_requested(:put, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/delegation").
+          with(body: JSON.dump(attributes)).
+          with(headers: { "Accept" => "application/json" })
+    end
+
+    it "returns the name servers of the domain" do
+      response = subject.change_domain_delegation(account_id, "example.com", attributes)
+      expect(response).to be_a(Dnsimple::Response)
+
+      expect(response.data).to match_array(%w(ns1.dnsimple.com ns2.dnsimple.com ns3.dnsimple.com ns4.dnsimple.com))
+    end
+  end
 end

--- a/spec/fixtures.http/changeDomainDelegation/success.http
+++ b/spec/fixtures.http/changeDomainDelegation/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Thu, 24 Mar 2016 11:17:01 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1458821049
+ETag: W/"cb540984f806b12ac437cc1f76092f90"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 0ea7bdd2-63ca-4eef-9c41-4a83d2fe0067
+X-Runtime: 2.845860
+Strict-Transport-Security: max-age=31536000
+
+{"data":["ns1.dnsimple.com","ns2.dnsimple.com","ns3.dnsimple.com","ns4.dnsimple.com"]}

--- a/spec/fixtures.http/getDomainDelegation/success-empty.http
+++ b/spec/fixtures.http/getDomainDelegation/success-empty.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Thu, 24 Mar 2016 11:13:41 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2393
+X-RateLimit-Reset: 1458821048
+ETag: W/"e0234245cb00aa260ccfa99a9a0b235e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: c88385f9-c8f7-435a-9060-0b1a27488b2b
+X-Runtime: 0.206440
+Strict-Transport-Security: max-age=31536000
+
+{"data":[]}

--- a/spec/fixtures.http/getDomainDelegation/success.http
+++ b/spec/fixtures.http/getDomainDelegation/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Thu, 24 Mar 2016 11:17:18 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2391
+X-RateLimit-Reset: 1458821048
+ETag: W/"cb540984f806b12ac437cc1f76092f90"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: e53ac7b5-0d26-45bc-9226-09c2d34be293
+X-Runtime: 0.192986
+Strict-Transport-Security: max-age=31536000
+
+{"data":["ns1.dnsimple.com","ns2.dnsimple.com","ns3.dnsimple.com","ns4.dnsimple.com"]}


### PR DESCRIPTION
Add support for the actions on https://developer.dnsimple.com/v2/registrar/delegation/

Vanity name server support will come in the future as this PR only tries to keep up with the Go client.