### PR TITLE
Handle no content type cases

### DIFF
--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -15,7 +15,8 @@ module Dnsimple
     private
 
     def message_from(http_response)
-      if http_response.headers["Content-Type"].start_with?("application/json")
+      content_type = http_response.headers["Content-Type"]
+      if content_type && content_type.start_with?("application/json")
         http_response.parsed_response["message"]
       else
         net_http_response = http_response.response

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -107,6 +107,13 @@ describe Dnsimple::Client do
       }.to raise_error(Dnsimple::RequestError, "502 Bad Gateway")
     end
 
+    it "raises RequestError in absence of content types" do
+      stub_request(:put, %r{/foo}).to_return(read_http_fixture("method-not-allowed.http"))
+
+      expect {
+        subject.execute(:put, "foo", {})
+      }.to raise_error(Dnsimple::RequestError, "405 Method Not Allowed")
+    end
   end
 
   describe "#request" do
@@ -164,6 +171,9 @@ describe Dnsimple::Client do
 
       subject.request(:post, 'foo', { something: "else" }, { headers: { "Content-Type" => "application/x-www-form-urlencoded" } })
     end
+
+    
+
   end
 
 end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -171,9 +171,6 @@ describe Dnsimple::Client do
 
       subject.request(:post, 'foo', { something: "else" }, { headers: { "Content-Type" => "application/x-www-form-urlencoded" } })
     end
-
-    
-
   end
 
 end

--- a/spec/fixtures.http/method-not-allowed.http
+++ b/spec/fixtures.http/method-not-allowed.http
@@ -1,0 +1,11 @@
+HTTP/1.1 405 Method Not Allowed
+Server: nginx
+Date: Fri, 15 Apr 2016 14:15:04 GMT
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 405 Method Not Allowed
+Allow: DELETE, GET, HEAD, PATCH, POST
+Cache-Control: no-cache
+X-Request-Id: 64c0a5e1-4cbb-4287-98a7-93085a77ac55
+X-Runtime: 0.050104
+


### PR DESCRIPTION
Some errors and responses will have no `Content-Type` header. Error generation will fail for those. This patch fixes the issue.