### PR TITLE
Do not require authentication for every request

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -192,7 +192,7 @@ module Dnsimple
 
       if proxy
         address, port = proxy.split(":")
-        { http_proxyaddr: address, http_proxyport: port }
+        options = { http_proxyaddr: address, http_proxyport: port }
       end
 
       options

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -170,8 +170,8 @@ module Dnsimple
 
     def request_options(custom_options = {})
       options = base_options
-      Extra.deep_merge!(options, auth_options)
-      Extra.deep_merge!(options, proxy_options)
+      add_auth_options!(options)
+      add_proxy_options!(options)
       Extra.deep_merge!(options, custom_options)
     end
 
@@ -185,27 +185,20 @@ module Dnsimple
       }
     end
 
-    def proxy_options
-      options = {}
-
+    def add_proxy_options!(options)
       if proxy
         address, port = proxy.split(":")
-        options = { http_proxyaddr: address, http_proxyport: port }
+        options[:http_proxyaddr] = address
+        options[:http_proxyport] = port
       end
-
-      options
     end
 
-    def auth_options
-      options = {}
-
+    def add_auth_options!(options)
       if password
-        options = { basic_auth: { username: username, password: password } }
+        options[:basic_auth] = { username: username, password: password }
       elsif access_token
-        options = { headers: { HEADER_AUTHORIZATION => "Bearer #{access_token}" } }
+        options[:headers][HEADER_AUTHORIZATION] = "Bearer #{access_token}"
       end
-
-      options
     end
 
     def content_type(headers)

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -206,7 +206,7 @@ module Dnsimple
       elsif access_token
         options = { headers: { HEADER_AUTHORIZATION => "Bearer #{access_token}" } }
       else
-        !authenticate or raise Error, "A password, domain API token or access token is required for all API requests."
+        !authenticate or raise Error, "A password, domain API token or access token is required."
       end
 
       options

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -172,7 +172,7 @@ module Dnsimple
       options = base_options
       Extra.deep_merge!(options, auth_options)
       Extra.deep_merge!(options, proxy_options)
-      Extra.deep_merge!(custom_options, options)
+      Extra.deep_merge!(options, custom_options)
     end
 
     def base_options

--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -169,10 +169,8 @@ module Dnsimple
     private
 
     def request_options(custom_options = {})
-      authenticate = custom_options.delete(:authenticate) { true }
-
       options = base_options
-      Extra.deep_merge!(options, auth_options(authenticate))
+      Extra.deep_merge!(options, auth_options)
       Extra.deep_merge!(options, proxy_options)
       Extra.deep_merge!(custom_options, options)
     end
@@ -198,15 +196,13 @@ module Dnsimple
       options
     end
 
-    def auth_options(authenticate)
+    def auth_options
       options = {}
 
       if password
         options = { basic_auth: { username: username, password: password } }
       elsif access_token
         options = { headers: { HEADER_AUTHORIZATION => "Bearer #{access_token}" } }
-      else
-        !authenticate or raise Error, "A password, domain API token or access token is required."
       end
 
       options

--- a/lib/dnsimple/extra.rb
+++ b/lib/dnsimple/extra.rb
@@ -13,20 +13,20 @@ module Dnsimple
     #   h1 = { a: true, b: { c: [1, 2, 3] } }
     #   h2 = { a: false, b: { x: [3, 4, 5] } }
     #
-    #   h1.deep_merge(h2) #=> { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
+    #   Extra.deep_merge(h1, h2) #=> { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
     #
     # Like with Hash#merge in the standard library, a block can be provided
     # to merge values:
     #
     #   h1 = { a: 100, b: 200, c: { c1: 100 } }
     #   h2 = { b: 250, c: { c1: 200 } }
-    #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
+    #   Extra.deep_merge(h1, h2) { |key, this_val, other_val| this_val + other_val }
     #   # => { a: 100, b: 450, c: { c1: 300 } }
     def self.deep_merge(this, other, &block)
       deep_merge!(this.dup, other, &block)
     end
 
-    # Same as +deep_merge+, but modifies +self+.
+    # Same as +deep_merge+, but modifies +this+ instead of returning a new hash.
     def self.deep_merge!(this, other, &block)
       other.each_pair do |current_key, other_value|
         this_value = this[current_key]

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -49,7 +49,7 @@ describe Dnsimple::Client do
 
       expect {
         subject.execute(:get, "test", {})
-      }.to raise_error(Dnsimple::Error, "A password, domain API token or access token is required for all API requests.")
+      }.to raise_error(Dnsimple::Error, "A password, domain API token or access token is required.")
     end
 
     it "can perform requests without requiring authentication" do

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -51,6 +51,15 @@ describe Dnsimple::Client do
         subject.execute(:get, "test", {})
       }.to raise_error(Dnsimple::Error, "A password, domain API token or access token is required for all API requests.")
     end
+
+    it "can perform requests without requiring authentication" do
+      stub_request(:any, %r{/test})
+
+      expect {
+        subject.execute(:get, "test", nil, authenticate: false)
+      }.not_to raise_error
+    end
+
   end
 
   describe "#get" do

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -178,6 +178,19 @@ describe Dnsimple::Client do
       subject = described_class.new(proxy: "example-proxy.com:4321")
       subject.request(:get, "test", nil, {})
     end
+
+    it "default options can be overriden" do
+      expect(HTTParty).to receive(:get).
+          with(
+              "#{subject.base_url}test",
+              format: :json,
+              headers: { "Accept" => "application/json", "User-Agent" => "dnsimple-custom-integration" }
+          ).
+          and_return(double("response", code: 200))
+
+      subject = described_class.new
+      subject.request(:get, "test", nil, headers: { "User-Agent" => "dnsimple-custom-integration" })
+    end
   end
 
 end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -43,22 +43,6 @@ describe Dnsimple::Client do
       expect(WebMock).to have_requested(:get, "https://api.dnsimple.com/test").
           with { |req| req.headers["Authorization"] == "Bearer access-token" }
     end
-
-    it "raises an error if there's no password, domain token or access token provided" do
-      subject = described_class.new(username: "user", oauth_client_id: "id", oauth_client_secret: "secret")
-
-      expect {
-        subject.execute(:get, "test", {})
-      }.to raise_error(Dnsimple::Error, "A password, domain API token or access token is required.")
-    end
-
-    it "can perform requests without requiring authentication" do
-      stub_request(:any, %r{/test})
-
-      expect {
-        subject.execute(:get, "test", nil, authenticate: false)
-      }.not_to raise_error
-    end
   end
 
   describe "#get" do
@@ -192,7 +176,7 @@ describe Dnsimple::Client do
           and_return(double('response', code: 200))
 
       subject = described_class.new(proxy: "example-proxy.com:4321")
-      subject.request(:get, "test", nil, authenticate: false)
+      subject.request(:get, "test", nil, {})
     end
   end
 

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -59,7 +59,6 @@ describe Dnsimple::Client do
         subject.execute(:get, "test", nil, authenticate: false)
       }.not_to raise_error
     end
-
   end
 
   describe "#get" do
@@ -179,6 +178,21 @@ describe Dnsimple::Client do
           and_return(double('response', code: 200))
 
       subject.request(:post, 'foo', { something: "else" }, { headers: { "Content-Type" => "application/x-www-form-urlencoded" } })
+    end
+
+    it "includes options for proxy support" do
+      expect(HTTParty).to receive(:get).
+          with(
+              "#{subject.base_url}test",
+              format: :json,
+              http_proxyaddr: "example-proxy.com",
+              http_proxyport: "4321",
+              headers: { 'Accept' => 'application/json', 'User-Agent' => "dnsimple-ruby/#{Dnsimple::VERSION}" }
+          ).
+          and_return(double('response', code: 200))
+
+      subject = described_class.new(proxy: "example-proxy.com:4321")
+      subject.request(:get, "test", nil, authenticate: false)
     end
   end
 


### PR DESCRIPTION
Closes #74

This PR introduces the ability of making requests without providing any of the supported authentication methods using the `options` parameter. If for any request you specify an option like `authenticate: false` no error will be risen if there are no credentials set.

The changes required to accommodate this feature are minimum (although I took the opportunity and spilt up the method that builds the final request options).