### PR TITLE
Adds support for the accounts endpoint

### DIFF
--- a/lib/dnsimple/client/accounts.rb
+++ b/lib/dnsimple/client/accounts.rb
@@ -2,6 +2,17 @@ module Dnsimple
   class Client
     module Accounts
 
+      # Lists the accounts the authenticated entity has access to.
+      #
+      # @see https://developer.dnsimple.com/v2/accounts
+      #
+      # @example List the accounts:
+      #   client.accounts.list
+      #
+      # @param  [Hash] options
+      # @return [Dnsimple::Response<Dnsimple::Struct::Account>]
+      #
+      # @raise  [Dnsimple::RequestError]
       def accounts(options = {})
         response = client.get(Client.versioned("/accounts"), options)
 

--- a/lib/dnsimple/client/accounts.rb
+++ b/lib/dnsimple/client/accounts.rb
@@ -1,0 +1,15 @@
+module Dnsimple
+  class Client
+    module Accounts
+
+      def accounts(options = {})
+        response = client.get(Client.versioned("/accounts"), options)
+
+        Dnsimple::Response.new(response, response["data"].map { |r| Struct::Account.new(r) })
+      end
+      alias list accounts
+      alias list_accounts accounts
+
+    end
+  end
+end

--- a/lib/dnsimple/client/clients.rb
+++ b/lib/dnsimple/client/clients.rb
@@ -1,6 +1,11 @@
 module Dnsimple
   class Client
 
+    # @return [Dnsimple::Client::AccountsService] The account-related API proxy.
+    def accounts
+      @services[:accounts] ||= Client::AccountsService.new(self)
+    end
+
     # @return [Dnsimple::Client::ContactsService] The contact-related API proxy.
     def contacts
       @services[:contacts] ||= Client::ContactsService.new(self)
@@ -88,6 +93,13 @@ module Dnsimple
         CollectionResponse.new(response.http_response, collection)
       end
 
+    end
+
+
+    require_relative 'accounts'
+
+    class AccountsService < ClientService
+      include Client::Accounts
     end
 
 

--- a/lib/dnsimple/struct/account.rb
+++ b/lib/dnsimple/struct/account.rb
@@ -7,6 +7,9 @@ module Dnsimple
 
       # @return [String] The account email.
       attr_accessor :email
+
+      # @return [String] The identifier of the plan the account is subscribed to.
+      attr_accessor :plan_identifier
     end
 
   end

--- a/spec/dnsimple/client/accounts_spec.rb
+++ b/spec/dnsimple/client/accounts_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Dnsimple::Client, ".accounts" do
+
+  subject { described_class.new(base_url: "https://api.dnsimple.test", access_token: "a1b2c3").accounts }
+
+
+  describe "#accounts" do
+    before do
+      stub_request(:get, %r{/v2/accounts$}).
+          to_return(read_http_fixture("accounts/success-user.http"))
+    end
+
+    it "builds the correct request" do
+      subject.accounts
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/accounts").
+          with(headers: { 'Accept' => 'application/json' })
+    end
+
+    it "returns the accouts" do
+      response = subject.accounts
+      expect(response).to be_a(Dnsimple::Response)
+
+      result = response.data
+      expect(result.first).to be_a(Dnsimple::Struct::Account)
+      expect(result.last).to be_a(Dnsimple::Struct::Account)
+    end
+  end
+
+end

--- a/spec/dnsimple/client/accounts_spec.rb
+++ b/spec/dnsimple/client/accounts_spec.rb
@@ -18,7 +18,7 @@ describe Dnsimple::Client, ".accounts" do
           with(headers: { 'Accept' => 'application/json' })
     end
 
-    it "returns the accouts" do
+    it "returns the accounts" do
       response = subject.accounts
       expect(response).to be_a(Dnsimple::Response)
 

--- a/spec/fixtures.http/accounts/success-account.http
+++ b/spec/fixtures.http/accounts/success-account.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 14 Jun 2016 12:02:58 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2391
+X-RateLimit-Reset: 1465908577
+ETag: W/"9ef3b4bf1f441a9b1cd6d7041bc181aa"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: f705b65b-3589-43ad-97ca-3b2821d49d81
+X-Runtime: 0.012661
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58.930Z","updated_at":"2016-06-03T15:02:26.325Z"}]}

--- a/spec/fixtures.http/accounts/success-user.http
+++ b/spec/fixtures.http/accounts/success-user.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 14 Jun 2016 12:05:38 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2390
+X-RateLimit-Reset: 1465908577
+ETag: W/"b8dc5b6e94652da599d15d4668b723b5"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 745455ba-3871-440d-b703-1448b9708c14
+X-Runtime: 0.014727
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58.930Z","updated_at":"2016-06-03T15:02:26.325Z"},{"id":456,"email":"ops@company.com","plan_identifier":"dnsimple-professional","created_at":"2012-03-16T16:02:54.736Z","updated_at":"2016-06-14T11:23:16.828Z"}]}


### PR DESCRIPTION
Adds support for the newly added accounts endpoint:

```
irb(main):009:0> client.accounts.list.data
=> [#<Dnsimple::Struct::Account:0x007fbcdb9b4a48 @id=63, @email="javier@dnsimple.com", @plan_identifier="dnsimple-professional">]
```